### PR TITLE
Typo on variable kmac_256 type definition.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -163,6 +163,6 @@ export var cshake_256: CshakeHash;
 export var cshake128: CshakeHash;
 export var cshake256: CshakeHash;
 export var kmac_128: KmacHash;
-export var kmac_256: kmacHash;
+export var kmac_256: KmacHash;
 export var kmac128: KmacHash;
 export var kmac256: KmacHash;


### PR DESCRIPTION
Typescript definition file has a typo on variable **kmac_256** class type. Type definition is not in PascalCase format. So when the file is used compilation throws an `/js-sha3/index.d.ts (166,22): Cannot find name 'kmacHash'` error.