### PR TITLE
Fixes inconsistent comparison for ArrayBuffer

### DIFF
--- a/src/sha3.js
+++ b/src/sha3.js
@@ -193,7 +193,7 @@
       if (type === 'object') {
         if (message === null) {
           throw new Error(INPUT_ERROR);
-        } else if (ARRAY_BUFFER && message.constructor === ArrayBuffer) {
+        } else if (ARRAY_BUFFER && message.constructor.name === "ArrayBuffer") {
           message = new Uint8Array(message);
         } else if (!Array.isArray(message)) {
           if (!ARRAY_BUFFER || !ArrayBuffer.isView(message)) {


### PR DESCRIPTION
We faced an issue where the conditional `message.constructor === ArrayBuffer` behaved inconsistently. When ran from jest, an ArrayBuffer instance returned false, while running the library directly returned true. Using the constructor name and comparing against a string solved the issue.