### PR TITLE
Fix error in arrayBuffer when there are extra bytes

### DIFF
--- a/src/sha3.js
+++ b/src/sha3.js
@@ -399,7 +399,7 @@
       }
     }
     if (extraBytes) {
-      array[i] = s[i];
+      array[j] = s[i];
       buffer = buffer.slice(0, bytes);
     }
     return buffer;


### PR DESCRIPTION
Hello, when the number of output bits is large the following occurs:
```
 h = shake256.create(40);
 h.update("");
 const a = new Uint8Array(h.arrayBuffer());
 a[4]; // 11 as expected

 h = shake256.create(32 * (34 + 1) + 8); 
 h.update("");
 const b = new Uint8Array(h.arrayBuffer());
 a[4]; // 70  but should be 11
```